### PR TITLE
Feature/kak/do not watch node modules

### DIFF
--- a/lib/budo.js
+++ b/lib/budo.js
@@ -33,7 +33,7 @@ module.exports = function ({ config, env, files, flyle, instrument, minify, outd
     live: {
       cache: true,
       debug: true,
-      expose: true
+      expose: false
     },
     middleware: [],
     poll: true,

--- a/lib/bundle-build.js
+++ b/lib/bundle-build.js
@@ -47,7 +47,10 @@ module.exports = function buildBundle ({
     })
 
   if (watch) {
-    pipeline.plugin(require('watchify'), { poll: true })
+    pipeline.plugin(require('watchify'), {
+      ignoreWatch: true,
+      poll: true
+    })
     pipeline.plugin(require('errorify'))
     pipeline.on('update', bundle)
     pipeline.on('log', logger.log)


### PR DESCRIPTION
Ignore `node_modules` with file watcher used by development server. Should speed rebuilding and lower CPU usage.

Connects azavea/echo-locator#49.
