### PR TITLE
Do not serve images with budo

### DIFF
--- a/lib/budo.js
+++ b/lib/budo.js
@@ -5,13 +5,16 @@ const budo = require('budo')
 const logger = require('./logger')
 const transformJs = require('./js-transform')
 
+// Do not serve files with these extensions in the bundle (see build.js)
+const copyFileExtensions = ['.json', '.png', '.svg', '.jpg', '.jpeg', '.bmp', '.tiff', '.webp']
+
 module.exports = function ({ config, env, files, flyle, instrument, minify, outdir, proxy, watch }) {
   logger.log('Starting budo server...')
 
   const budoFiles = []
   files.map(file => {
-    // Skip JSON files, which are written separately. Otherwise, they will be bundled.
-    if (path.extname(file[0]) !== '.json') {
+    // Skip files which are written separately. Otherwise, they will be bundled.
+    if (copyFileExtensions.indexOf(path.extname(file[0])) >= 0) {
       budoFiles.push(file.join(':'))
     }
   })


### PR DESCRIPTION
Fix the (ignored) parse errors on attempting to bundle images no longer wrapped as modules when running the local dev server.
